### PR TITLE
Simple performance improvement @ Rootbeer.isRooted

### DIFF
--- a/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
+++ b/rootbeerlib/src/main/java/com/scottyab/rootbeer/RootBeer.java
@@ -35,18 +35,10 @@ public class RootBeer {
      * @return true, we think there's a good *indication* of root | false good *indication* of no root (could still be cloaked)
      */
     public boolean isRooted() {
-        boolean rootManagement = detectRootManagementApps();
-        boolean potentiallyDangerousApps = detectPotentiallyDangerousApps();
-        boolean suBinary = checkForBinary("su");
-        boolean busyboxBinary = checkForBinary("busybox");
-        boolean dangerousProps = checkForDangerousProps();
-        boolean rwSystem = checkForRWPaths();
-        boolean testKeys = detectTestKeys();
-        boolean testSuExists = checkSuExists();
-        boolean testRootNative = checkForRootNative();
 
-        return rootManagement || potentiallyDangerousApps || suBinary
-                || busyboxBinary || dangerousProps || rwSystem || testKeys || testSuExists || testRootNative;
+        return detectRootManagementApps() || detectPotentiallyDangerousApps() || checkForBinary("su")
+                || checkForBinary("busybox") || checkForDangerousProps() || checkForRWPaths()
+                || detectTestKeys() || checkSuExists() || checkForRootNative();
     }
 
     /**


### PR DESCRIPTION
Even though it facilitates debugging, the way the code was written would cause all the root checks to be executed, even when the first check already detected that the device was rooted.

The way the code is written now (with inline method calls), isRooted() can return as soon as one of the methods (in order) return true, and the other methods in the OR chain don't need to be executed.
